### PR TITLE
split gui class unrelated modules

### DIFF
--- a/crypt4gh_gui/__main__.py
+++ b/crypt4gh_gui/__main__.py
@@ -13,9 +13,7 @@ def main():
     print("4. Select a file or a directory for upload (not both)")
     print("5. Write SFTP username, server and port to SFTP Credentials")
     print("6. Load your SFTP RSA key")
-    print(
-        "7. Click [Encrypt and Upload File(s)] to upload selected file or directory"
-    )
+    print("7. Click [Encrypt and Upload File(s)] to upload selected file or directory")
     print("8. Password for private key and RSA key will be prompted\n")
     root.mainloop()
 

--- a/crypt4gh_gui/crypt4gh_gui.py
+++ b/crypt4gh_gui/crypt4gh_gui.py
@@ -90,6 +90,9 @@ class GUI:
         self.sftp_key_label = tk.Label(window, text="SFTP Key (Optional)")
         self.sftp_key_label.grid(column=0, row=8, sticky=tk.W)
         self.sftp_key_value = tk.StringVar()
+        self.sftp_key_field = tk.Entry(window, width=OS_CONFIG["field_width"], textvariable=self.sftp_key_value)
+        self.sftp_key_field.grid(column=0, row=9, sticky=tk.W)
+        self.sftp_key_field.config(state="disabled")
         sftp_key_file = data.get("sftp_key_file", None)
         if sftp_key_file and Path(sftp_key_file).is_file():
             self.sftp_key_value.set(sftp_key_file)

--- a/crypt4gh_gui/crypt4gh_gui.py
+++ b/crypt4gh_gui/crypt4gh_gui.py
@@ -263,7 +263,6 @@ class GUI:
                 hostname=sftp_hostname,
                 port=sftp_port,
                 sftp_auth=sftp_auth,
-                sftp_key=self.sftp_key_value.get(),
             )
             public_key = get_public_key(self.their_key_value.get())
             self.sftp_upload(sftp=sftp, target=self.file_value.get(), private_key=private_key, public_key=public_key)
@@ -322,8 +321,9 @@ class GUI:
 
     def test_sftp_connection(self, username=None, hostname=None, port=22, rsa_key=None, sftp_pass=None):
         """Test SFTP connection and determine key type before uploading."""
-        _sftp_connection(username, hostname, port, rsa_key, sftp_pass)
+        sftp_auth = _sftp_connection(username, hostname, port, rsa_key, sftp_pass)
         self.write_config()  # save fields
+        return sftp_auth
 
     def sftp_upload(self, sftp=None, target=None, private_key=None, public_key=None):
         """Upload file or directory."""

--- a/crypt4gh_gui/crypt4gh_gui.py
+++ b/crypt4gh_gui/crypt4gh_gui.py
@@ -1,11 +1,10 @@
 """CSC SDS SFTP GUI."""
 
-import os
 import sys
 import json
 import getpass
 import tkinter as tk
-import paramiko
+from typing import Dict
 
 from tkinter.simpledialog import askstring
 from tkinter.filedialog import askopenfilename, askdirectory
@@ -14,7 +13,9 @@ from functools import partial
 from platform import system
 
 from crypt4gh.keys import c4gh, get_private_key, get_public_key
-from crypt4gh.lib import encrypt
+
+from .sftp import _sftp_connection, _sftp_upload_file, _sftp_upload_directory, _sftp_client
+from pathlib import Path
 
 OS_CONFIG = {"field_width": 40, "config_button_width": 25}
 if system() == "Linux":
@@ -39,10 +40,11 @@ class GUI:
         self.window = window
         self.window.resizable(False, False)
         self.window.title("CSC Sensitive Data Submission Tool")
-        sys.stdout.write = self.print_redirect  # print to activity log instead of console
+        # print to activity log instead of console
+        sys.stdout.write = self.print_redirect  # type:ignore
 
         # Load previous values from config file
-        self.config_file = os.path.join(os.path.expanduser("~"), ".crypt4gh_config.json")
+        self.config_file = Path(Path.home()).joinpath(".crypt4gh_config.json")
         data = self.read_config(self.config_file)
 
         # 1st column FIELDS AND LABELS
@@ -53,8 +55,9 @@ class GUI:
         self.my_key_field = tk.Entry(window, width=OS_CONFIG["field_width"], textvariable=self.my_key_value)
         self.my_key_field.grid(column=0, row=1, sticky=tk.W)
         self.my_key_field.config(state="disabled")
-        if data.get("private_key_file") is not None and os.path.isfile(data.get("private_key_file")):
-            self.my_key_value.set(data.get("private_key_file"))
+        private_key_file = data.get("private_key_file", None)
+        if private_key_file and Path(private_key_file).is_file():
+            self.my_key_value.set(private_key_file)
 
         self.their_key_label = tk.Label(window, text="Recipient Public Key")
         self.their_key_label.grid(column=0, row=2, sticky=tk.W)
@@ -62,8 +65,9 @@ class GUI:
         self.their_key_field = tk.Entry(window, width=OS_CONFIG["field_width"], textvariable=self.their_key_value)
         self.their_key_field.grid(column=0, row=3, sticky=tk.W)
         self.their_key_field.config(state="disabled")
-        if data.get("public_key_file") is not None and os.path.isfile(data.get("public_key_file")):
-            self.their_key_value.set(data.get("public_key_file"))
+        public_key_file = data.get("public_key_file", None)
+        if public_key_file and Path(public_key_file).is_file():
+            self.their_key_value.set(public_key_file)
 
         self.file_label = tk.Label(window, text="File or Directory to Upload")
         self.file_label.grid(column=0, row=4, sticky=tk.W)
@@ -79,17 +83,16 @@ class GUI:
         self.sftp_value.set(placeholder_sftp_value)
         self.sftp_field = tk.Entry(window, width=OS_CONFIG["field_width"], textvariable=self.sftp_value)
         self.sftp_field.grid(column=0, row=7, sticky=tk.W)
-        if data.get("sftp_credentials") is not None and len(data.get("sftp_credentials")) > 0:
-            self.sftp_value.set(data.get("sftp_credentials"))
+        sftp_credentials = data.get("sftp_credentials", None)
+        if sftp_credentials and len(sftp_credentials) > 0:
+            self.sftp_value.set(sftp_credentials)
 
         self.sftp_key_label = tk.Label(window, text="SFTP Key (Optional)")
         self.sftp_key_label.grid(column=0, row=8, sticky=tk.W)
         self.sftp_key_value = tk.StringVar()
-        self.sftp_key_field = tk.Entry(window, width=OS_CONFIG["field_width"], textvariable=self.sftp_key_value)
-        self.sftp_key_field.grid(column=0, row=9, sticky=tk.W)
-        self.sftp_key_field.config(state="disabled")
-        if data.get("sftp_key_file") is not None and os.path.isfile(data.get("sftp_key_file")):
-            self.sftp_key_value.set(data.get("sftp_key_file"))
+        sftp_key_file = data.get("sftp_key_file", None)
+        if sftp_key_file and Path(sftp_key_file).is_file():
+            self.sftp_key_value.set(sftp_key_file)
 
         self.activity_label = tk.Label(window, text="Activity Log")
         self.activity_label.grid(column=0, row=10, sticky=tk.W)
@@ -199,92 +202,95 @@ class GUI:
         else:
             print(f"Unknown action: {action}")
 
-    def password_prompt(self, action):
-        """Ask user for private key password."""
+    def _generate_password(self):
         password = ""
-        if action == "generate":
-            # Passphrase for private key generation
-            password = askstring("Private Key Passphrase", "Private Key Passphrase", show="*")
+        # Passphrase for private key generation
+        password = askstring("Private Key Passphrase", "Private Key Passphrase", show="*")
+        # This if-clause is for preventing error messages
+        if password is None:
+            return
+        while len(password) == 0:
+            password = askstring("Private Key Passphrase", "Passphrase can't be empty", show="*")
             # This if-clause is for preventing error messages
             if password is None:
                 return
+        # Use crypt4gh module to generate private and public keys
+        c4gh.generate(
+            f"{getpass.getuser()}_crypt4gh.key",
+            f"{getpass.getuser()}_crypt4gh.pub",
+            callback=partial(self.mock_callback, password),
+        )
+        print("Key pair has been generated, your private key will be auto-loaded the next time you launch this tool")
+        print(f"Private key: {getpass.getuser()}_crypt4gh.key")
+        print(f"Public key: {getpass.getuser()}_crypt4gh.pub")
+
+    def _get_private_key(self, password):
+        private_key = None
+        try:
+            private_key = get_private_key(self.my_key_value.get(), partial(self.mock_callback, password))
+        except Exception:
+            self.passwords["private_key"] = ""
+            print("Incorrect private key passphrase")
+            return
+        # Ask for RSA key password
+        sftp_password = self.passwords["sftp_key"]
+        while len(sftp_password) == 0:
+            sftp_password = askstring("SFTP Passphrase", "Passphrase for SFTP KEY or USERNAME", show="*")
+            if self.remember_pass.get():
+                self.passwords["sftp_key"] = sftp_password
+            # This if-clause is for preventing error messages
+            if sftp_password is None:
+                return
+        # Test SFTP connection
+        sftp_credentials = self.sftp_value.get().split("@")
+        sftp_username = sftp_credentials[0]
+        sftp_hostname = sftp_credentials[1].split(":")[0]
+        sftp_port = sftp_credentials[1].split(":")[1]
+        sftp_auth = self.test_sftp_connection(
+            username=sftp_username,
+            hostname=sftp_hostname,
+            port=sftp_port,
+            rsa_key=self.sftp_key_value.get(),
+            sftp_pass=sftp_password,
+        )
+        # Encrypt and upload
+        if private_key and sftp_auth:
+            sftp = _sftp_client(
+                username=sftp_username,
+                hostname=sftp_hostname,
+                port=sftp_port,
+                sftp_auth=sftp_auth,
+                sftp_key=self.sftp_key_value.get(),
+            )
+            public_key = get_public_key(self.their_key_value.get())
+            self.sftp_upload(sftp=sftp, target=self.file_value.get(), private_key=private_key, public_key=public_key)
+        else:
+            print("Could not form SFTP connection.")
+
+    def _get_encryption_password(self):
+        password = ""
+        # Check that all fields are filled before asking for password
+        if self.my_key_value.get() and self.their_key_value.get() and self.file_value.get() and self.sftp_value.get():
+            # Ask for passphrase for private key encryption
+            password = self.passwords["private_key"]
             while len(password) == 0:
-                password = askstring("Private Key Passphrase", "Passphrase can't be empty", show="*")
+                password = askstring("Private Key Passphrase", "Passphrase for PRIVATE KEY", show="*")
+                if self.remember_pass.get():
+                    self.passwords["private_key"] = password
                 # This if-clause is for preventing error messages
                 if password is None:
                     return
-            # Use crypt4gh module to generate private and public keys
-            c4gh.generate(
-                f"{getpass.getuser()}_crypt4gh.key",
-                f"{getpass.getuser()}_crypt4gh.pub",
-                callback=partial(self.mock_callback, password),
-            )
-            print(
-                "Key pair has been generated, your private key will be auto-loaded the next time you launch this tool"
-            )
-            print(f"Private key: {getpass.getuser()}_crypt4gh.key")
-            print(f"Public key: {getpass.getuser()}_crypt4gh.pub")
+            self._get_private_key(password)
+        else:
+            print("All fields must be filled before file upload can be started")
+
+    def password_prompt(self, action):
+        """Ask user for private key password."""
+
+        if action == "generate":
+            self._generate_password()
         elif action == "encrypt":
-            # Check that all fields are filled before asking for password
-            if (
-                self.my_key_value.get()
-                and self.their_key_value.get()
-                and self.file_value.get()
-                and self.sftp_value.get()
-            ):
-                # Ask for passphrase for private key encryption
-                password = self.passwords["private_key"]
-                while len(password) == 0:
-                    password = askstring("Private Key Passphrase", "Passphrase for PRIVATE KEY", show="*")
-                    if self.remember_pass.get():
-                        self.passwords["private_key"] = password
-                    # This if-clause is for preventing error messages
-                    if password is None:
-                        return
-                private_key = None
-                try:
-                    private_key = get_private_key(self.my_key_value.get(), partial(self.mock_callback, password))
-                except Exception:
-                    self.passwords["private_key"] = ""
-                    print("Incorrect private key passphrase")
-                    return
-                # Ask for RSA key password
-                sftp_password = self.passwords["sftp_key"]
-                while len(sftp_password) == 0:
-                    sftp_password = askstring("SFTP Passphrase", "Passphrase for SFTP KEY or USERNAME", show="*")
-                    if self.remember_pass.get():
-                        self.passwords["sftp_key"] = sftp_password
-                    # This if-clause is for preventing error messages
-                    if sftp_password is None:
-                        return
-                # Test SFTP connection
-                sftp_credentials = self.sftp_value.get().split("@")
-                sftp_username = sftp_credentials[0]
-                sftp_hostname = sftp_credentials[1].split(":")[0]
-                sftp_port = sftp_credentials[1].split(":")[1]
-                sftp_auth = self.test_sftp_connection(
-                    username=sftp_username,
-                    hostname=sftp_hostname,
-                    port=sftp_port,
-                    rsa_key=self.sftp_key_value.get(),
-                    sftp_pass=sftp_password,
-                )
-                # Encrypt and upload
-                if private_key and sftp_auth:
-                    sftp = self.sftp_client(
-                        username=sftp_username,
-                        hostname=sftp_hostname,
-                        port=sftp_port,
-                        sftp_auth=sftp_auth,
-                    )
-                    public_key = get_public_key(self.their_key_value.get())
-                    self.sftp_upload(
-                        sftp=sftp, target=self.file_value.get(), private_key=private_key, public_key=public_key
-                    )
-                else:
-                    print("Could not form SFTP connection.")
-            else:
-                print("All fields must be filled before file upload can be started")
+            self._get_encryption_password()
         else:
             print(f"Unknown action: {action}")
 
@@ -303,193 +309,36 @@ class GUI:
         with open(self.config_file, "w") as f:
             f.write(json.dumps(data))
 
-    def read_config(self, path):
+    def read_config(self, path) -> Dict[str, str]:
         """Read field values from previous run if they exist."""
         data = {}
-        if os.path.isfile(path):
+        if Path(path).is_file():
             with open(path, "r") as f:
                 data = json.loads(f.read())
         return data
 
     def test_sftp_connection(self, username=None, hostname=None, port=22, rsa_key=None, sftp_pass=None):
         """Test SFTP connection and determine key type before uploading."""
-        print("Testing connection to SFTP server.")
-        print(
-            f'SFTP testing timeout is: {os.environ.get("SFTP_TIMEOUT", 5)}. You can change this with environment variable $SFTP_TIMEOUT'
-        )
-        # Test if key is RSA
-        try:
-            print("Testing if SFTP key is of type RSA")
-            client = paramiko.SSHClient()
-            paramiko_key = paramiko.RSAKey.from_private_key_file(rsa_key, password=sftp_pass)
-            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            client.connect(
-                hostname,
-                allow_agent=False,
-                look_for_keys=False,
-                port=port,
-                timeout=int(os.environ.get("SFTP_TIMEOUT", 5)),
-                username=username,
-                pkey=paramiko_key,
-            )
-            print("SFTP test connection: OK")
-            self.write_config()  # save fields
-            return paramiko_key
-        except Exception as e:
-            print(f"SFTP Error: {e}")
-        finally:
-            client.close()
-        # Test if key is ed25519
-        try:
-            print("Testing if SFTP key is of type Ed25519")
-            client = paramiko.SSHClient()
-            paramiko_key = paramiko.ed25519key.Ed25519Key(filename=rsa_key, password=sftp_pass)
-            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            client.connect(
-                hostname,
-                allow_agent=False,
-                look_for_keys=False,
-                port=port,
-                timeout=int(os.environ.get("SFTP_TIMEOUT", 5)),
-                username=username,
-                pkey=paramiko_key,
-            )
-            print("SFTP test connection: OK")
-            self.write_config()  # save fields
-            return paramiko_key
-        except Exception as e:
-            print(f"SFTP Error: {e}")
-        finally:
-            client.close()
-        # Authenticating with password, if key is not set
-        try:
-            print("Testing if SFTP auth scheme is username+password")
-            client = paramiko.SSHClient()
-            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            client.connect(
-                hostname,
-                allow_agent=False,
-                look_for_keys=False,
-                port=port,
-                timeout=int(os.environ.get("SFTP_TIMEOUT", 5)),
-                username=username,
-                password=sftp_pass,
-            )
-            print("SFTP test connection: OK")
-            self.write_config()  # save fields
-            return sftp_pass
-        except Exception as e:
-            print(f"SFTP Error: {e}")
-        finally:
-            client.close()
-        return False  # neither keys or password worked
-
-    def sftp_client(self, username=None, hostname=None, port=22, sftp_auth=None):
-        """SFTP client."""
-        try:
-            print(f"Connecting to {hostname} as {username}.")
-            transport = paramiko.Transport((hostname, int(port)))
-            if self.sftp_key_value.get():
-                # If SFTP key is set, authenticate with that
-                transport.connect(username=username, pkey=sftp_auth)
-            else:
-                # If key is not set, authenticate with password
-                transport.connect(username=username, password=sftp_auth)
-            sftp = paramiko.SFTPClient.from_transport(transport)
-            print("SFTP connected, ready to upload files.")
-            return sftp
-        except paramiko.BadHostKeyException as e:
-            print(f"SFTP error: {e}")
-            raise Exception("BadHostKeyException on " + hostname)
-        except paramiko.AuthenticationException as e:
-            print(f"SFTP authentication failed, error: {e}")
-            raise Exception("AuthenticationException on " + hostname)
-        except paramiko.SSHException as e:
-            print(f"Could not connect to {hostname}, error: {e}")
-            raise Exception("SSHException on " + hostname)
-        except Exception as e:
-            print(f"SFTP Error: {e}")
-
-        return False
+        _sftp_connection(username, hostname, port, rsa_key, sftp_pass)
+        self.write_config()  # save fields
 
     def sftp_upload(self, sftp=None, target=None, private_key=None, public_key=None):
         """Upload file or directory."""
         print("Starting upload process.")
 
-        if os.path.isfile(target):
-            self.upload_file(
+        if Path(target).is_file():
+            _sftp_upload_file(
                 sftp=sftp,
                 source=target,
-                destination=os.path.basename(target),
+                destination=Path(target).name,
                 private_key=private_key,
                 public_key=public_key,
             )
 
-        if os.path.isdir(target):
-            self.upload_directory(sftp=sftp, directory=target, private_key=private_key, public_key=public_key)
+        if Path(target).is_dir():
+            _sftp_upload_directory(sftp=sftp, directory=target, private_key=private_key, public_key=public_key)
 
         # Close SFTP connection
         print("Disconnecting SFTP.")
         sftp.close()
         print("SFTP has been disconnected.")
-
-    def upload_file(self, sftp=None, source=None, destination=None, private_key=None, public_key=None):
-        """Upload a single file."""
-        verified = self.verify_crypt4gh_header(source)
-        if verified:
-            print(f"File {source} was recognised as a Crypt4GH file, and will be uploaded.")
-            print(f"Uploading {source}")
-            sftp.put(source, destination)
-            print(f"{source} has been uploaded.")
-        else:
-            # Encrypt before uploading
-            print(f"File {source} was not recognised as a Crypt4GH file, and must be encrypted before uploading.")
-            self.encrypt_file(file=source, private_key_file=private_key, recipient_public_key=public_key)
-            print(f"Uploading {source}.c4gh")
-            sftp.put(f"{source}.c4gh", f"{destination}.c4gh")
-            print(f"{source}.c4gh has been uploaded.")
-            print(f"Removing auto-encrypted file {source}.c4gh")
-            os.remove(f"{source}.c4gh")
-            print(f"{source}.c4gh removed")
-
-    def upload_directory(self, sftp=None, directory=None, private_key=None, public_key=None):
-        """Upload directory."""
-        sftp_dir = ""
-        for item in os.walk(directory):
-            sftp_dir = os.path.join(sftp_dir, os.path.basename(item[0]))
-            try:
-                sftp.mkdir(sftp_dir)
-                print(f"Directory {sftp_dir} created.")
-            except OSError:
-                print(f"Skipping directory {sftp_dir} creation, as it already exists.")
-            for sub_item in item[2]:
-                self.upload_file(
-                    sftp=sftp,
-                    source=os.path.join(item[0], sub_item),
-                    destination=f"/{os.path.join(sftp_dir, sub_item)}",
-                    private_key=private_key,
-                    public_key=public_key,
-                )
-
-    def encrypt_file(self, file=None, private_key_file=None, recipient_public_key=None):
-        """Encrypt a file with Crypt4GH."""
-        print(f"Encrypting {file} as {file}.c4gh")
-        original_file = open(file, "rb")
-        encrypted_file = open(f"{file}.c4gh", "wb")
-        encrypt([(0, private_key_file, recipient_public_key)], original_file, encrypted_file)
-        original_file.close()
-        encrypted_file.close()
-        print("Encryption has finished.")
-
-    def verify_crypt4gh_header(self, file=None):
-        """Verify, that a file has Crypt4GH header."""
-        print("Verifying file Crypt4GH header.")
-        with open(file, "rb") as f:
-            header = f.read()[:8]
-            if header == b"crypt4gh":
-                return True
-            else:
-                return False
-
-
-

--- a/crypt4gh_gui/encrypt.py
+++ b/crypt4gh_gui/encrypt.py
@@ -1,0 +1,23 @@
+from crypt4gh.lib import encrypt
+
+
+def encrypt_file(file=None, private_key_file=None, recipient_public_key=None):
+    """Encrypt a file with Crypt4GH."""
+    print(f"Encrypting {file} as {file}.c4gh")
+    original_file = open(file, "rb")
+    encrypted_file = open(f"{file}.c4gh", "wb")
+    encrypt([(0, private_key_file, recipient_public_key)], original_file, encrypted_file)
+    original_file.close()
+    encrypted_file.close()
+    print("Encryption has finished.")
+
+
+def verify_crypt4gh_header(file=None):
+    """Verify, that a file has Crypt4GH header."""
+    print("Verifying file Crypt4GH header.")
+    with open(file, "rb") as f:
+        header = f.read()[:8]
+        if header == b"crypt4gh":
+            return True
+        else:
+            return False

--- a/crypt4gh_gui/sftp.py
+++ b/crypt4gh_gui/sftp.py
@@ -99,7 +99,7 @@ def _sftp_upload_directory(sftp=None, directory=None, private_key=None, public_k
     for item in os.walk(directory):
         sftp_dir = Path(sftp_dir).joinpath(Path(item[0]).name)
         try:
-            sftp.mkdir(sftp_dir)
+            sftp.mkdir(sftp_dir.name)
             print(f"Directory {sftp_dir} created.")
         except OSError:
             print(f"Skipping directory {sftp_dir} creation, as it already exists.")

--- a/crypt4gh_gui/sftp.py
+++ b/crypt4gh_gui/sftp.py
@@ -113,12 +113,12 @@ def _sftp_upload_directory(sftp=None, directory=None, private_key=None, public_k
             )
 
 
-def _sftp_client(username=None, hostname=None, port=22, sftp_auth=None, sftp_key=None):
+def _sftp_client(username=None, hostname=None, port=22, sftp_auth=None):
     """SFTP client."""
     try:
         print(f"Connecting to {hostname} as {username}.")
         transport = paramiko.Transport((hostname, int(port)))
-        if sftp_key.get():
+        if type(sftp_auth) in [paramiko.rsakey.RSAKey, paramiko.ed25519key.Ed25519Key]:
             # If SFTP key is set, authenticate with that
             transport.connect(username=username, pkey=sftp_auth)
         else:

--- a/crypt4gh_gui/sftp.py
+++ b/crypt4gh_gui/sftp.py
@@ -1,0 +1,142 @@
+import paramiko
+import os
+from .encrypt import encrypt_file, verify_crypt4gh_header
+from pathlib import Path
+
+
+def _sftp_connection(username=None, hostname=None, port=22, rsa_key=None, sftp_pass=None):
+    """Test SFTP connection and determine key type before uploading."""
+    print("Testing connection to SFTP server.")
+    print(
+        f'SFTP testing timeout is: {os.environ.get("SFTP_TIMEOUT", 5)}. You can change this with environment variable $SFTP_TIMEOUT'
+    )
+    # Test if key is RSA
+    client = paramiko.SSHClient()
+    try:
+        print("Testing if SFTP key is of type RSA")
+        paramiko_key = paramiko.RSAKey.from_private_key_file(rsa_key, password=sftp_pass)
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.connect(
+            hostname,
+            allow_agent=False,
+            look_for_keys=False,
+            port=port,
+            timeout=int(os.environ.get("SFTP_TIMEOUT", 5)),
+            username=username,
+            pkey=paramiko_key,
+        )
+        print("SFTP test connection: OK")
+        return paramiko_key
+    except Exception as e:
+        print(f"SFTP Error: {e}")
+    finally:
+        client.close()
+    # Test if key is ed25519
+    try:
+        print("Testing if SFTP key is of type Ed25519")
+        paramiko_key = paramiko.ed25519key.Ed25519Key(filename=rsa_key, password=sftp_pass)
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.connect(
+            hostname,
+            allow_agent=False,
+            look_for_keys=False,
+            port=port,
+            timeout=int(os.environ.get("SFTP_TIMEOUT", 5)),
+            username=username,
+            pkey=paramiko_key,
+        )
+        print("SFTP test connection: OK")
+        return paramiko_key
+    except Exception as e:
+        print(f"SFTP Error: {e}")
+    finally:
+        client.close()
+    # Authenticating with password, if key is not set
+    try:
+        print("Testing if SFTP auth scheme is username+password")
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.connect(
+            hostname,
+            allow_agent=False,
+            look_for_keys=False,
+            port=port,
+            timeout=int(os.environ.get("SFTP_TIMEOUT", 5)),
+            username=username,
+            password=sftp_pass,
+        )
+        print("SFTP test connection: OK")
+        return sftp_pass
+    except Exception as e:
+        print(f"SFTP Error: {e}")
+    finally:
+        client.close()
+    return False  # neither keys or password worked
+
+
+def _sftp_upload_file(sftp=None, source=None, destination=None, private_key=None, public_key=None):
+    """Upload a single file."""
+    verified = verify_crypt4gh_header(source)
+    if verified:
+        print(f"File {source} was recognised as a Crypt4GH file, and will be uploaded.")
+        print(f"Uploading {source}")
+        sftp.put(source, destination)
+        print(f"{source} has been uploaded.")
+    else:
+        # Encrypt before uploading
+        print(f"File {source} was not recognised as a Crypt4GH file, and must be encrypted before uploading.")
+        encrypt_file(file=source, private_key_file=private_key, recipient_public_key=public_key)
+        print(f"Uploading {source}.c4gh")
+        sftp.put(f"{source}.c4gh", f"{destination}.c4gh")
+        print(f"{source}.c4gh has been uploaded.")
+        print(f"Removing auto-encrypted file {source}.c4gh")
+        os.remove(f"{source}.c4gh")
+        print(f"{source}.c4gh removed")
+
+
+def _sftp_upload_directory(sftp=None, directory=None, private_key=None, public_key=None):
+    """Upload directory."""
+    sftp_dir = ""
+    for item in os.walk(directory):
+        sftp_dir = Path(sftp_dir).joinpath(Path(item[0]).name)
+        try:
+            sftp.mkdir(sftp_dir)
+            print(f"Directory {sftp_dir} created.")
+        except OSError:
+            print(f"Skipping directory {sftp_dir} creation, as it already exists.")
+        for sub_item in item[2]:
+            _sftp_upload_file(
+                sftp=sftp,
+                source=Path(item[0]).joinpath(sub_item),
+                destination=f"/{Path(sftp_dir).joinpath(sub_item)}",
+                private_key=private_key,
+                public_key=public_key,
+            )
+
+
+def _sftp_client(username=None, hostname=None, port=22, sftp_auth=None, sftp_key=None):
+    """SFTP client."""
+    try:
+        print(f"Connecting to {hostname} as {username}.")
+        transport = paramiko.Transport((hostname, int(port)))
+        if sftp_key.get():
+            # If SFTP key is set, authenticate with that
+            transport.connect(username=username, pkey=sftp_auth)
+        else:
+            # If key is not set, authenticate with password
+            transport.connect(username=username, password=sftp_auth)
+        sftp = paramiko.SFTPClient.from_transport(transport)
+        print("SFTP connected, ready to upload files.")
+        return sftp
+    except paramiko.BadHostKeyException as e:
+        print(f"SFTP error: {e}")
+        raise Exception("BadHostKeyException on " + hostname)
+    except paramiko.AuthenticationException as e:
+        print(f"SFTP authentication failed, error: {e}")
+        raise Exception("AuthenticationException on " + hostname)
+    except paramiko.SSHException as e:
+        print(f"Could not connect to {hostname}, error: {e}")
+        raise Exception("SSHException on " + hostname)
+    except Exception as e:
+        print(f"SFTP Error: {e}")
+
+    return False

--- a/crypt4gh_gui/sftp.py
+++ b/crypt4gh_gui/sftp.py
@@ -112,6 +112,7 @@ def _sftp_upload_directory(sftp=None, directory=None, private_key=None, public_k
                 public_key=public_key,
             )
 
+
 def _sftp_client(username=None, hostname=None, port=22, sftp_auth=None):
     """SFTP client."""
     try:

--- a/crypt4gh_gui/sftp.py
+++ b/crypt4gh_gui/sftp.py
@@ -99,19 +99,18 @@ def _sftp_upload_directory(sftp=None, directory=None, private_key=None, public_k
     for item in os.walk(directory):
         sftp_dir = Path(sftp_dir).joinpath(Path(item[0]).name)
         try:
-            sftp.mkdir(sftp_dir.name)
+            sftp.mkdir(str(sftp_dir))
             print(f"Directory {sftp_dir} created.")
         except OSError:
             print(f"Skipping directory {sftp_dir} creation, as it already exists.")
         for sub_item in item[2]:
             _sftp_upload_file(
                 sftp=sftp,
-                source=Path(item[0]).joinpath(sub_item),
-                destination=f"/{Path(sftp_dir).joinpath(sub_item)}",
+                source=str(Path(item[0]).joinpath(sub_item)),
+                destination=f"/{str(Path(sftp_dir).joinpath(sub_item))}",
                 private_key=private_key,
                 public_key=public_key,
             )
-
 
 def _sftp_client(username=None, hostname=None, port=22, sftp_auth=None):
     """SFTP client."""

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description="FUSE client for accessing the SDA.",
     long_description="",
     packages=["crypt4gh_gui"],
-    entry_points={"console_scripts": ["sds_uploader=crypt4gh_gui.crypt4gh_gui:main"]},
+    entry_points={"console_scripts": ["sds_uploader=crypt4gh_gui.__main__:main"]},
     platforms="any",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
sftp and encrypt have their own module

move to pathlib

data dict remove get redundant code. `is not None` is not a pythonic check

@teemukataja needs testing