### PR TITLE
compromise fix for windows build: display cmd behind gui app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,12 +75,12 @@ jobs:
         run: |
           echo '${{ secrets.DOCKER_PASSWORD }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
           docker pull cscfi/pyinstaller
-          docker run --rm -v "${PWD}:/builder" cscfi/pyinstaller --noconsole --onefile crypt4gh_gui.py --name ${{ matrix.asset_name }}
+          docker run --rm -v "${PWD}:/builder" cscfi/pyinstaller --onefile crypt4gh_gui.py --name ${{ matrix.asset_name }}
           sudo chown -R $USER:$GROUP dist/
       - name: Build artifact
         if: matrix.os != 'ubuntu-latest'
         run: |
-          pyinstaller --noconsole --onefile crypt4gh_gui.py --name ${{ matrix.asset_name }}
+          pyinstaller --onefile crypt4gh_gui.py --name ${{ matrix.asset_name }}
       - name: Build Asset
         run: |
           cd ./dist


### PR DESCRIPTION
release `v1.3.1`

The Windows executable crashes, because pyinstaller is hiding the console (does not affect linux or mac, or when running with python)
- compromise fix for windows: don't hide `cmd`
  - fix it better later by refactoring how the logging works